### PR TITLE
[Models] Criada funcionalidade de utilizar o data nas funções

### DIFF
--- a/controllers/fetch_daily_transactions.go
+++ b/controllers/fetch_daily_transactions.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 type JsonRespRaw struct {
@@ -13,40 +14,49 @@ type JsonRespRaw struct {
 	Value     float64 `json:"value"`
 }
 
-func FetchDailyTransactions() (retTransactions []JsonRespRaw) {
-	testTransactions := `[
-		{
-			"date": "2022-09-21",
-			"mode": "PIX",
-			"receiving": "true",
-			"recipient": "378.432.324-89",
-			"value": 3232.32
-		},
-		{
-			"date": "2022-09-22",
-			"mode": "PIX",
-			"receiving": "false",
-			"recipient": "378.432.324-89",
-			"value": 23.32
-		},
-		{
-			"date": "2022-09-21",
-			"mode": "PIX",
-			"receiving": "true",
-			"recipient": "323.432.324-89",
-			"value": 123.32
-		},
-		{
-			"date": "2022-09-23",
-			"mode": "PIX",
-			"receiving": "true",
-			"recipient": "378.431.874-89",
-			"value": 1.32
-		}
-	]`
+var testTransactions = `[
+	{
+		"date": "2022-09-21",
+		"mode": "PIX",
+		"receiving": "true",
+		"recipient": "378.432.324-89",
+		"value": 3232.32
+	},
+	{
+		"date": "2022-09-22",
+		"mode": "PIX",
+		"receiving": "false",
+		"recipient": "378.432.324-89",
+		"value": 23.32
+	},
+	{
+		"date": "2022-09-21",
+		"mode": "PIX",
+		"receiving": "true",
+		"recipient": "323.432.324-89",
+		"value": 123.32
+	},
+	{
+		"date": "2022-09-23",
+		"mode": "PIX",
+		"receiving": "true",
+		"recipient": "378.431.874-89",
+		"value": 1.32
+	}
+]`
 
-	if err := json.Unmarshal([]byte(testTransactions), &retTransactions); err != nil {
-		fmt.Printf("%v %v\n", 56, err)
+func FetchDailyTransactions(date time.Time) (retTransactions []JsonRespRaw) {
+	currentDate := fmt.Sprintf("%v-%02v-%02v", date.Year(), int(date.Month()), date.Day())
+
+	var iterTransactions []JsonRespRaw
+	if err := json.Unmarshal([]byte(testTransactions), &iterTransactions); err != nil {
+		fmt.Println(err)
+	}
+
+	for _, transaction := range iterTransactions {
+		if transaction.Date == currentDate {
+			retTransactions = append(retTransactions, transaction)
+		}
 	}
 
 	return retTransactions

--- a/controllers/fetch_daily_transactions_test.go
+++ b/controllers/fetch_daily_transactions_test.go
@@ -1,9 +1,29 @@
 package controllers
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func testPrint(date time.Time) {
+	trans := FetchDailyTransactions(date)
+	for _, tran := range trans {
+		fmt.Println(tran)
+	}
+}
 
 func TestFetchDailyTransactions(t *testing.T) {
-	transactions := FetchDailyTransactions()
+	date1 := time.Date(2022, 9, 21, 0, 0, 0, 0, time.UTC)
+	date2 := time.Date(2022, 9, 22, 0, 0, 0, 0, time.UTC)
+	date3 := time.Date(2022, 9, 23, 0, 0, 0, 0, time.UTC)
+
+	transactions := append(
+		FetchDailyTransactions(date1),
+		FetchDailyTransactions(date2)...,
+	)
+	transactions = append(transactions, FetchDailyTransactions(date3)...)
+
 	expected := []JsonRespRaw{
 		{
 			Date:      "2022-09-21",
@@ -13,18 +33,18 @@ func TestFetchDailyTransactions(t *testing.T) {
 			Value:     3232.32,
 		},
 		{
-			Date:      "2022-09-22",
-			Mode:      "PIX",
-			Receiving: "false",
-			Recipient: "378.432.324-89",
-			Value:     23.32,
-		},
-		{
 			Date:      "2022-09-21",
 			Mode:      "PIX",
 			Receiving: "true",
 			Recipient: "323.432.324-89",
 			Value:     123.32,
+		},
+		{
+			Date:      "2022-09-22",
+			Mode:      "PIX",
+			Receiving: "false",
+			Recipient: "378.432.324-89",
+			Value:     23.32,
 		},
 		{
 			Date:      "2022-09-23",
@@ -35,9 +55,13 @@ func TestFetchDailyTransactions(t *testing.T) {
 		},
 	}
 
+	if len(expected) != len(transactions) {
+		t.Errorf("Lenghts of expectedInput and de.TransactionInput differ, got %v, expected %v", len(transactions), len(expected))
+	}
+
 	for i := range expected {
 		if transactions[i].Date != expected[i].Date {
-			t.Errorf("Output Date (%q) not equal to expected (%q)", transactions[i].Date, expected[i].Date)
+			t.Errorf("%v Output Date (%q) not equal to expected (%q)", i, transactions[i].Date, expected[i].Date)
 		} else if transactions[i].Mode != expected[i].Mode {
 			t.Errorf("Output Mode (%q) not equal to expected (%q)", transactions[i].Mode, expected[i].Mode)
 		} else if transactions[i].Receiving != expected[i].Receiving {

--- a/models/current_day_extract.go
+++ b/models/current_day_extract.go
@@ -16,7 +16,7 @@ func (de *DayExtract) GetDayExtract(date time.Time) string {
 	// Setting initial date for the day extract
 	de.Date = date
 	// Fetching the data by a given date
-	transactions := FetchAndTransformDailyTransactions()
+	transactions := FetchAndTransformDailyTransactions(date)
 
 	// Separate all the transactions into input and output transaction
 	for _, transaction := range transactions {

--- a/models/current_day_extract_test.go
+++ b/models/current_day_extract_test.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
@@ -28,11 +27,11 @@ func TestGetDayExtract(t *testing.T) {
 	expectedOutput := []Transaction{}
 
 	if len(expectedInput) != len(de.TransactionInput) {
-		t.Errorf("Lenghts of expectedInput and de.TransactionInput differ, got: %v and %v", len(expectedInput), len(de.TransactionInput))
+		t.Errorf("Lenghts of expectedInput and de.TransactionInput differ, got %v, expected %v", len(de.TransactionInput), len(expectedInput))
 	}
 
 	if len(expectedOutput) != len(de.TransactionOutput) {
-		t.Errorf("Lenghts of expectedOutput and de.TransactionOutput differ, got: %v and %v", len(expectedOutput), len(de.TransactionOutput))
+		t.Errorf("Lenghts of expectedOutput and de.TransactionOutput differ, got %v, expected %v", len(de.TransactionOutput), len(expectedOutput))
 	}
 
 	for i := range expectedInput {
@@ -58,6 +57,4 @@ func TestGetDayExtract(t *testing.T) {
 			t.Errorf("Output Value (%v) not equal to (%v)", expectedOutput[i].Value, de.TransactionOutput[i].Value)
 		}
 	}
-
-	fmt.Printf("%+v\n", de)
 }

--- a/models/month_extract.go
+++ b/models/month_extract.go
@@ -10,3 +10,8 @@ type MonthExtract struct {
 	FinalBalance     float64      `json:"totalBalance"`
 	ExtractsPerMonth []DayExtract `json:"extractsPerMonth"`
 }
+
+func (me *MonthExtract) GetMonthExtract() (s string) {
+
+	return s
+}

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/ghastcmd/plc-bank-extract/controllers"
 )
@@ -58,8 +59,8 @@ func getTransactionReceiving(receiving string) (bool, error) {
 	}
 }
 
-func FetchAndTransformDailyTransactions() (transactions []Transaction) {
-	rawTransactions := controllers.FetchDailyTransactions()
+func FetchAndTransformDailyTransactions(date time.Time) (transactions []Transaction) {
+	rawTransactions := controllers.FetchDailyTransactions(date)
 
 	for _, rawTransaction := range rawTransactions {
 		mode := getTransactionMode(rawTransaction.Mode)

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -1,6 +1,9 @@
 package models
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestFetchAndTransformDailyTransaction(t *testing.T) {
 	expected := []Transaction{
@@ -12,15 +15,15 @@ func TestFetchAndTransformDailyTransaction(t *testing.T) {
 		},
 		{
 			Mode:      Pix,
-			Receiving: false,
-			Recipient: "378.432.324-89",
-			Value:     23.32,
-		},
-		{
-			Mode:      Pix,
 			Receiving: true,
 			Recipient: "323.432.324-89",
 			Value:     123.32,
+		},
+		{
+			Mode:      Pix,
+			Receiving: false,
+			Recipient: "378.432.324-89",
+			Value:     23.32,
 		},
 		{
 			Mode:      Pix,
@@ -30,13 +33,21 @@ func TestFetchAndTransformDailyTransaction(t *testing.T) {
 		},
 	}
 
-	transactions := FetchAndTransformDailyTransactions()
+	date1 := time.Date(2022, 9, 21, 0, 0, 0, 0, time.UTC)
+	date2 := time.Date(2022, 9, 22, 0, 0, 0, 0, time.UTC)
+	date3 := time.Date(2022, 9, 23, 0, 0, 0, 0, time.UTC)
+
+	transactions := append(
+		FetchAndTransformDailyTransactions(date1),
+		FetchAndTransformDailyTransactions(date2)...,
+	)
+	transactions = append(transactions, FetchAndTransformDailyTransactions(date3)...)
 
 	for i := range expected {
 		if transactions[i].Mode != expected[i].Mode {
 			t.Errorf("Output Mode (%q) not equal to expected (%q)", transactions[i].Mode, expected[i].Mode)
 		} else if transactions[i].Receiving != expected[i].Receiving {
-			t.Errorf("Output Receiving (%v) not equal to expected (%v)", transactions[i].Receiving, expected[i].Receiving)
+			t.Errorf("%v Output Receiving (%v) not equal to expected (%v)", i, transactions[i].Receiving, expected[i].Receiving)
 		} else if transactions[i].Recipient != expected[i].Recipient {
 			t.Errorf("Output Recipient (%q) not equal to expected (%q)", transactions[i].Recipient, expected[i].Recipient)
 		} else if transactions[i].Value != expected[i].Value {


### PR DESCRIPTION
Foi criada a funcionalidade de poder utilizar a data nas funções que fazem a captura dos dados provenientes de uma base de testes, desse modo, pode-se obter uma resposta mais adequada à especificação que diz de separar os balanços por dia.

Ainda não foi implementada a funcionalidade mestra de pegar todas as datas do mês inteiro.