### PR TITLE
[Models] Implementado método de conseguir o extrato por mês

### DIFF
--- a/models/month_extract.go
+++ b/models/month_extract.go
@@ -1,6 +1,8 @@
 package models
 
-import "time"
+import (
+	"time"
+)
 
 type MonthExtract struct {
 	Month            time.Month   `json:"month"`
@@ -11,7 +13,30 @@ type MonthExtract struct {
 	ExtractsPerMonth []DayExtract `json:"extractsPerMonth"`
 }
 
-func (me *MonthExtract) GetMonthExtract() (s string) {
+func (me *MonthExtract) GetMonthExtract(date time.Time) (s string) {
+	year := date.Year()
+	month := date.Month()
+
+	// Assigning month
+	me.Month = month
+
+	// Calulating the last day of current month
+	firstOfMonth := time.Date(year, month, 1, 0, 0, 0, 0, date.Location())
+	lastOfMonth := firstOfMonth.AddDate(0, 1, -1)
+
+	// Fetching all transaction data for the entire month
+	last := lastOfMonth.Day()
+	for i := firstOfMonth.Day(); i <= last; i++ {
+		currentDate := time.Date(year, month, i, 0, 0, 0, 0, date.Location())
+		var de DayExtract
+		de.GetDayExtract(currentDate)
+		me.ExtractsPerMonth = append(me.ExtractsPerMonth, de)
+
+		// Calculate total inputs
+		me.TotalInputs += de.InputValue
+		// Calculate total outputs
+		me.TotalOutputs += de.OutputValue
+	}
 
 	return s
 }

--- a/models/month_extract_test.go
+++ b/models/month_extract_test.go
@@ -1,0 +1,101 @@
+package models
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func roundComparison6Places(value float64) float64 {
+	return (math.Ceil(value*1e7) / 1e7) - 1e-7
+}
+
+type comparisonTest struct {
+	Day                int
+	TransactionsInput  []Transaction
+	TransactionsOutput []Transaction
+}
+
+func TestGetMonthExtract(t *testing.T) {
+	// Get a random date
+	date := time.Date(2022, 9, 21, 0, 0, 0, 0, time.UTC)
+
+	// Getting the MonthExtract object
+	var me MonthExtract
+	me.GetMonthExtract(date)
+
+	// Comparing Total values
+	expectedInput := 3356.96
+	expectedOutput := 23.32
+	roundedGotTotalInputs := roundComparison6Places(me.TotalInputs)
+	if roundedGotTotalInputs != expectedInput {
+		t.Errorf("Invalid TotalInputs, got %v expected %v", roundedGotTotalInputs, expectedInput)
+	}
+	if me.TotalOutputs != expectedOutput {
+		t.Errorf("Invalid TotalOutputs, got %v expected %v", me.TotalOutputs, expectedOutput)
+	}
+
+	// Comparing the days gotten
+	expectedLenght := 30
+	if lenght := len(me.ExtractsPerMonth); lenght != expectedLenght {
+		t.Errorf("Invalid ExtractsPerMonth lenght, expected %v got %v", expectedLenght, lenght)
+	}
+
+	// Comparing the days gotten
+	expectedDays := []comparisonTest{
+		{
+			Day: 21,
+			TransactionsInput: []Transaction{
+				{
+					Mode:      Pix,
+					Receiving: true,
+					Recipient: "378.432.324-89",
+					Value:     3232.32,
+				},
+				{
+					Mode:      Pix,
+					Receiving: true,
+					Recipient: "323.432.324-89",
+					Value:     123.32,
+				},
+			},
+		},
+		{
+			Day: 22,
+			TransactionsOutput: []Transaction{
+				{
+					Mode:      Pix,
+					Receiving: false,
+					Recipient: "378.432.324-89",
+					Value:     23.32,
+				},
+			},
+		},
+		{
+			Day: 23,
+			TransactionsInput: []Transaction{
+				{
+					Mode:      Pix,
+					Receiving: true,
+					Recipient: "378.431.874-89",
+					Value:     1.32,
+				},
+			},
+		},
+	}
+
+	for _, test := range expectedDays {
+		// Checking for transactions inputs
+		for i, transaction := range test.TransactionsInput {
+			if expTransaction := me.ExtractsPerMonth[test.Day-1].TransactionInput[i]; transaction != expTransaction {
+				t.Errorf("Invalid value for TransactionInput, expected %v got %v", transaction, expTransaction)
+			}
+		}
+		// Checking for transactions outputs
+		for i, transaction := range test.TransactionsOutput {
+			if expTransaction := me.ExtractsPerMonth[test.Day-1].TransactionOutput[i]; transaction != expTransaction {
+				t.Errorf("Invalid value for TransactionInput, expected %v got %v", transaction, expTransaction)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Foi implementado código para que o sistema possa adquirir o extrato de todo o mês a partir da utilização de uma função do objeto MonthExtract, desse modo, pode-se obter dados estruturados sobre todas as transações que ocorreram no mês requisitado.

Ainda falta implementar algum modo de conseguir obter o saldo da conta no inicio do mês e compará-lo com o saldo do final do mês.