### PR TITLE
[Tests] Removido cadeia de condicionais nos testes

### DIFF
--- a/controllers/fetch_daily_transactions_test.go
+++ b/controllers/fetch_daily_transactions_test.go
@@ -62,13 +62,17 @@ func TestFetchDailyTransactions(t *testing.T) {
 	for i := range expected {
 		if transactions[i].Date != expected[i].Date {
 			t.Errorf("%v Output Date (%q) not equal to expected (%q)", i, transactions[i].Date, expected[i].Date)
-		} else if transactions[i].Mode != expected[i].Mode {
+		}
+		if transactions[i].Mode != expected[i].Mode {
 			t.Errorf("Output Mode (%q) not equal to expected (%q)", transactions[i].Mode, expected[i].Mode)
-		} else if transactions[i].Receiving != expected[i].Receiving {
+		}
+		if transactions[i].Receiving != expected[i].Receiving {
 			t.Errorf("Output Receiving (%q) not equal to expected (%q)", transactions[i].Receiving, expected[i].Receiving)
-		} else if transactions[i].Recipient != expected[i].Recipient {
+		}
+		if transactions[i].Recipient != expected[i].Recipient {
 			t.Errorf("Output Recipient (%q) not equal to expected (%q)", transactions[i].Recipient, expected[i].Recipient)
-		} else if transactions[i].Value != expected[i].Value {
+		}
+		if transactions[i].Value != expected[i].Value {
 			t.Errorf("Output Value (%v) not equal to expected (%v)", transactions[i].Value, expected[i].Value)
 		}
 	}

--- a/models/current_day_extract_test.go
+++ b/models/current_day_extract_test.go
@@ -37,11 +37,14 @@ func TestGetDayExtract(t *testing.T) {
 	for i := range expectedInput {
 		if expectedInput[i].Mode != de.TransactionInput[i].Mode {
 			t.Errorf("Output Mode (%v) not equal to (%v)", expectedInput[i].Mode, de.TransactionInput[i].Mode)
-		} else if expectedInput[i].Receiving != de.TransactionInput[i].Receiving {
+		}
+		if expectedInput[i].Receiving != de.TransactionInput[i].Receiving {
 			t.Errorf("Output Receiving (%v) not equal to (%v)", expectedInput[i].Receiving, de.TransactionInput[i].Receiving)
-		} else if expectedInput[i].Recipient != de.TransactionInput[i].Recipient {
+		}
+		if expectedInput[i].Recipient != de.TransactionInput[i].Recipient {
 			t.Errorf("Output Recipient (%v) not equal to (%v)", expectedInput[i].Recipient, de.TransactionInput[i].Recipient)
-		} else if expectedInput[i].Value != de.TransactionInput[i].Value {
+		}
+		if expectedInput[i].Value != de.TransactionInput[i].Value {
 			t.Errorf("Output Value (%v) not equal to (%v)", expectedInput[i].Value, de.TransactionInput[i].Value)
 		}
 	}
@@ -49,11 +52,14 @@ func TestGetDayExtract(t *testing.T) {
 	for i := range expectedOutput {
 		if expectedOutput[i].Mode != de.TransactionOutput[i].Mode {
 			t.Errorf("Output Mode (%v) not equal to (%v)", expectedOutput[i].Mode, de.TransactionOutput[i].Mode)
-		} else if expectedOutput[i].Receiving != de.TransactionOutput[i].Receiving {
+		}
+		if expectedOutput[i].Receiving != de.TransactionOutput[i].Receiving {
 			t.Errorf("Output Receiving (%v) not equal to (%v)", expectedOutput[i].Receiving, de.TransactionOutput[i].Receiving)
-		} else if expectedOutput[i].Recipient != de.TransactionOutput[i].Recipient {
+		}
+		if expectedOutput[i].Recipient != de.TransactionOutput[i].Recipient {
 			t.Errorf("Output Recipient (%v) not equal to (%v)", expectedOutput[i].Recipient, de.TransactionOutput[i].Recipient)
-		} else if expectedOutput[i].Value != de.TransactionOutput[i].Value {
+		}
+		if expectedOutput[i].Value != de.TransactionOutput[i].Value {
 			t.Errorf("Output Value (%v) not equal to (%v)", expectedOutput[i].Value, de.TransactionOutput[i].Value)
 		}
 	}

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -46,11 +46,14 @@ func TestFetchAndTransformDailyTransaction(t *testing.T) {
 	for i := range expected {
 		if transactions[i].Mode != expected[i].Mode {
 			t.Errorf("Output Mode (%q) not equal to expected (%q)", transactions[i].Mode, expected[i].Mode)
-		} else if transactions[i].Receiving != expected[i].Receiving {
+		}
+		if transactions[i].Receiving != expected[i].Receiving {
 			t.Errorf("%v Output Receiving (%v) not equal to expected (%v)", i, transactions[i].Receiving, expected[i].Receiving)
-		} else if transactions[i].Recipient != expected[i].Recipient {
+		}
+		if transactions[i].Recipient != expected[i].Recipient {
 			t.Errorf("Output Recipient (%q) not equal to expected (%q)", transactions[i].Recipient, expected[i].Recipient)
-		} else if transactions[i].Value != expected[i].Value {
+		}
+		if transactions[i].Value != expected[i].Value {
 			t.Errorf("Output Value (%v) not equal to expected (%v)", transactions[i].Value, expected[i].Value)
 		}
 	}


### PR DESCRIPTION
Foi observado que alguns testes não estavam sendo executados após um deles falhar, isso se deve ao 'if-else' que tinha quando iria testar, o que criava uma cadeia de IFs que removia a natureza de "testar tudo", invés de testar até uma falha.